### PR TITLE
Don't round the tick end value

### DIFF
--- a/rangebar/src/com/appyvet/rangebar/RangeBar.java
+++ b/rangebar/src/com/appyvet/rangebar/RangeBar.java
@@ -1249,7 +1249,9 @@ public class RangeBar extends View {
      * @param tickIndex the index to set the value for
      */
     private String getPinValue(int tickIndex) {
-        float tickValue = (tickIndex * mTickInterval) + mTickStart;
+        float tickValue = (tickIndex == (mTickCount - 1))
+                            ? mTickEnd
+                            : (tickIndex * mTickInterval) + mTickStart;
         String xValue = mTickMap.get(tickValue);
         if (xValue == null) {
             if (tickValue == Math.ceil(tickValue)) {


### PR DESCRIPTION
When fetching the last tick value always return the set end value instead of the calculated value, because if the start and end values don't fit with the given interval, the last value is rounded and lost.