### PR TITLE
Don't convert connectingLineWeight from dp to px twice

### DIFF
--- a/rangebar/src/com/appyvet/rangebar/ConnectingLine.java
+++ b/rangebar/src/com/appyvet/rangebar/ConnectingLine.java
@@ -45,14 +45,10 @@ public class ConnectingLine {
 
         final Resources res = ctx.getResources();
 
-        float connectingLineWeight1 = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP,
-                connectingLineWeight,
-                res.getDisplayMetrics());
-
         // Initialize the paint, set values
         mPaint = new Paint();
         mPaint.setColor(connectingLineColor);
-        mPaint.setStrokeWidth(connectingLineWeight1);
+        mPaint.setStrokeWidth(connectingLineWeight);
         mPaint.setStrokeCap(Paint.Cap.ROUND);
         mPaint.setAntiAlias(true);
 


### PR DESCRIPTION
If you previously used the same value for connectingLineWeight and barWeight, one will be twice as thin as the other. That's because the conversion of connectingLineWeight from dp to px is done twice, once in RangeBar.rangeBarInit and once in the constructor of ConnectingLine
