### PR TITLE
Fix pin text alignment and adds the "fromRight" parameter

### DIFF
--- a/rangebar/res/values/attrs.xml
+++ b/rangebar/res/values/attrs.xml
@@ -19,6 +19,7 @@
         <attr name="rangeBarPaddingBottom" format="dimension"/>
         <attr name="selectorColor" format="reference|color"/>
         <attr name="rangeBar" format="boolean"/>
+        <attr name="fromRight" format="boolean"/>
         <attr name="temporaryPins" format="boolean"/>
         <attr name="connectingLineWeight" format="dimension"/>
         <attr name="connectingLineColor" format="reference|color"/>

--- a/rangebar/src/com/appyvet/rangebar/ConnectingLine.java
+++ b/rangebar/src/com/appyvet/rangebar/ConnectingLine.java
@@ -62,24 +62,14 @@ public class ConnectingLine {
     // Package-Private Methods /////////////////////////////////////////////////
 
     /**
-     * Draw the connecting line between the two thumbs in rangebar.
-     *
-     * @param canvas     the Canvas to draw to
-     * @param leftThumb  the left thumb
-     * @param rightThumb the right thumb
-     */
-    public void draw(Canvas canvas, PinView leftThumb, PinView rightThumb) {
-        canvas.drawLine(leftThumb.getX(), mY, rightThumb.getX(), mY, mPaint);
-    }
-
-    /**
      * Draw the connecting line between for single slider.
      *
      * @param canvas     the Canvas to draw to
-     * @param rightThumb the right thumb
-     * @param leftMargin the left margin
+     * @param left the left side of the connecting line
+     * @param right the right side of the connecting line
      */
-    public void draw(Canvas canvas, float leftMargin, PinView rightThumb) {
-        canvas.drawLine(leftMargin, mY, rightThumb.getX(), mY, mPaint);
+    public void draw(Canvas canvas, float left, float right) {
+        canvas.drawLine(left, mY, right, mY, mPaint);
     }
+
 }

--- a/rangebar/src/com/appyvet/rangebar/PinView.java
+++ b/rangebar/src/com/appyvet/rangebar/PinView.java
@@ -291,10 +291,12 @@ class PinView extends View {
             calibrateTextSize(mTextPaint, text, mBounds.width());
             mTextPaint.getTextBounds(text, 0, text.length(), mBounds);
             mTextPaint.setTextAlign(Paint.Align.CENTER);
+
             mPin.setColorFilter(mPinFilter);
             mPin.draw(canvas);
+            float pinCenterY = mY - mPinRadiusPx -  mPinPadding;
             canvas.drawText(text,
-                    mX, mY - mPinRadiusPx - mPinPadding + mTextYPadding,
+                    mX, pinCenterY + mBounds.height() / 2.0f,
                     mTextPaint);
         }
         super.draw(canvas);

--- a/rangebar/src/com/appyvet/rangebar/RangeBar.java
+++ b/rangebar/src/com/appyvet/rangebar/RangeBar.java
@@ -168,6 +168,8 @@ public class RangeBar extends View {
 
     private boolean mIsRangeBar = true;
 
+    private boolean mIsFromRight = false; // when we are not a range bar, are we showing the connecting line from the right or the left (default)
+
     private float mPinPadding = DEFAULT_PIN_PADDING_DP;
 
     private float mBarPaddingBottom = DEFAULT_BAR_PADDING_BOTTOM_DP;
@@ -252,6 +254,7 @@ public class RangeBar extends View {
         bundle.putFloat("PIN_PADDING", mPinPadding);
         bundle.putFloat("BAR_PADDING_BOTTOM", mBarPaddingBottom);
         bundle.putBoolean("IS_RANGE_BAR", mIsRangeBar);
+        bundle.putBoolean("IS_FROM_RIGHT", mIsFromRight);
         bundle.putBoolean("ARE_PINS_TEMPORARY", mArePinsTemporary);
         bundle.putInt("LEFT_INDEX", mLeftIndex);
         bundle.putInt("RIGHT_INDEX", mRightIndex);
@@ -291,6 +294,7 @@ public class RangeBar extends View {
             mPinPadding = bundle.getFloat("PIN_PADDING");
             mBarPaddingBottom = bundle.getFloat("BAR_PADDING_BOTTOM");
             mIsRangeBar = bundle.getBoolean("IS_RANGE_BAR");
+            mIsFromRight = bundle.getBoolean("IS_FROM_RIGHT");
             mArePinsTemporary = bundle.getBoolean("ARE_PINS_TEMPORARY");
 
             mLeftIndex = bundle.getInt("LEFT_INDEX");
@@ -405,18 +409,25 @@ public class RangeBar extends View {
         super.onDraw(canvas);
 
         mBar.draw(canvas);
+
+        float conLineLeft, conLineRight;
         if (mIsRangeBar) {
-            mConnectingLine.draw(canvas, mLeftThumb, mRightThumb);
-            if (drawTicks) {
-                mBar.drawTicks(canvas);
-            }
-            mLeftThumb.draw(canvas);
+            conLineLeft = mLeftThumb.getX();
+            conLineRight = mRightThumb.getX();
         } else {
-            mConnectingLine.draw(canvas, getMarginLeft(), mRightThumb);
-            if (drawTicks) {
-                mBar.drawTicks(canvas);
-            }
+            conLineLeft = mIsFromRight ? mRightThumb.getX() : getHorizontalMargin();
+            conLineRight = mIsFromRight ? getWidth() - getHorizontalMargin() : mRightThumb.getX();
         }
+
+        mConnectingLine.draw(canvas, conLineLeft, conLineRight);
+        if (drawTicks) {
+            mBar.drawTicks(canvas);
+        }
+
+        if (mIsRangeBar) {
+            mLeftThumb.draw(canvas);
+        }
+
         mRightThumb.draw(canvas);
 
     }
@@ -1127,7 +1138,6 @@ public class RangeBar extends View {
             mBarPaddingBottom = ta.getDimension(R.styleable.RangeBar_rangeBarPaddingBottom,
                     TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP,
                             DEFAULT_BAR_PADDING_BOTTOM_DP, getResources().getDisplayMetrics()));
-            mIsRangeBar = ta.getBoolean(R.styleable.RangeBar_rangeBar, true);
             mArePinsTemporary = ta.getBoolean(R.styleable.RangeBar_temporaryPins, true);
 
             float density = getResources().getDisplayMetrics().density;
@@ -1137,6 +1147,7 @@ public class RangeBar extends View {
                     DEFAULT_MAX_PIN_FONT_SP * density);
 
             mIsRangeBar = ta.getBoolean(R.styleable.RangeBar_rangeBar, true);
+            mIsFromRight = ta.getBoolean(R.styleable.RangeBar_fromRight, false);
         } finally {
             ta.recycle();
         }
@@ -1147,7 +1158,7 @@ public class RangeBar extends View {
      */
     private void createBar() {
         mBar = new Bar(getContext(),
-                getMarginLeft(),
+                getHorizontalMargin(),
                 getYPos(),
                 getBarLength(),
                 mTickCount,
@@ -1187,7 +1198,7 @@ public class RangeBar extends View {
                 .init(ctx, yPos, 0, mPinColor, mTextColor, mCircleSize, mCircleColor,mCircleBoundaryColor, mCircleBoundarySize
                         , mMinPinFont, mMaxPinFont, false);
 
-        float marginLeft = getMarginLeft();
+        float marginLeft = getHorizontalMargin();
         float barLength = getBarLength();
 
         // Initialize thumbs to the desired indices
@@ -1206,7 +1217,7 @@ public class RangeBar extends View {
      *
      * @return float marginLeft
      */
-    private float getMarginLeft() {
+    private float getHorizontalMargin() {
         return Math.max(mExpandedPinRadius, mCircleSize);
     }
 
@@ -1225,7 +1236,7 @@ public class RangeBar extends View {
      * @return float barLength
      */
     private float getBarLength() {
-        return (getWidth() - 2 * getMarginLeft());
+        return (getWidth() - 2 * getHorizontalMargin());
     }
 
     /**


### PR DESCRIPTION
Improves the vertical alignment of text within pins (was off a little bit).

Added a new "fromRight" parameter that allows to draw the connecting line from the right end of the bar rather than the left hand (only applies when rangeBar = false).