### PR TITLE
Fixed bug in RangeBar

### DIFF
--- a/rangebar/src/com/appyvet/rangebar/RangeBar.java
+++ b/rangebar/src/com/appyvet/rangebar/RangeBar.java
@@ -1360,7 +1360,7 @@ public class RangeBar extends View {
         int newLeftIndex = mIsRangeBar ? mBar.getNearestTickIndex(mLeftThumb) : 0;
         int newRightIndex = mBar.getNearestTickIndex(mRightThumb);
 
-        final int componentLeft = getLeft() + getPaddingLeft();
+        final int componentLeft = getPaddingLeft();
         final int componentRight = getRight() - getPaddingRight() - componentLeft;
 
         if (x <= componentLeft) {


### PR DESCRIPTION
You shouldn't be using getLeft() when computing componentLeft. X is event.GetX() which is a relative location to the view itself, in this case RangeBar. You need to detect if x <= 0. Because if x is less than 0 it means that you are outside and to the left of the RangeBar. If X is greater than 0 you are still inside the RangeBar view. This was creating a bug where the selector would jump to index 0 when it shouldn't be.