### PR TITLE
Fix an issue with the right pin being moved on a click to the left of equal pins

### DIFF
--- a/materialrangebar/src/main/java/com/appyvet/materialrangebar/RangeBar.java
+++ b/materialrangebar/src/main/java/com/appyvet/materialrangebar/RangeBar.java
@@ -1282,6 +1282,33 @@ public class RangeBar extends View {
     }
 
     /**
+     * Gets the distance between x and the left pin. If the left and right pins are equal, this
+     * returns 0 if x is < the pins' position. Also returns 0 if the bar is not a range bar.
+     *
+     * @param x the x-coordinate to be checked
+     * @return the distance between x and the left pin, or 0 if the pins are equal and x is to the left.
+     * Also returns 0 if the bar is not a range bar.
+     */
+    private float getLeftThumbXDistance(float x) {
+        if (isRangeBar()) {
+            float leftThumbX = mLeftThumb.getX();
+            return leftThumbX == mRightThumb.getX() && x < leftThumbX ? 0 : Math.abs(leftThumbX - x);
+        } else {
+            return 0;
+        }
+    }
+
+    /**
+     * Gets the distance between x and the right pin
+     *
+     * @param x the x-coordinate to be checked
+     * @return the distance between x and the right pin
+     */
+    private float getRightThumbXDistance(float x) {
+        return Math.abs(mRightThumb.getX() - x);
+    }
+
+    /**
      * Handles a {@link android.view.MotionEvent#ACTION_DOWN} event.
      *
      * @param x the x-coordinate of the down action
@@ -1322,8 +1349,8 @@ public class RangeBar extends View {
 
         } else {
 
-            float leftThumbXDistance = mIsRangeBar ? Math.abs(mLeftThumb.getX() - x) : 0;
-            float rightThumbXDistance = Math.abs(mRightThumb.getX() - x);
+            float leftThumbXDistance = getLeftThumbXDistance(x);
+            float rightThumbXDistance = getRightThumbXDistance(x);
 
             if (leftThumbXDistance < rightThumbXDistance) {
                 if (mIsRangeBar) {


### PR DESCRIPTION
Currently on the range bar, if the pins are both set to the same value and the user *clicks* on the bar to the *left* of the pins, the right pin would move to the click position instead of the left. This means that the right pin is actually to the left of the left pin.

This PR addresses the issue by performing an additional check for equality between the 2 pins while calculating the distance.