### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ allprojects {
 
 ```groovy
 dependencies {
-    compile 'com.appyvet:materialrangebar:1.4.1'
+    implementation 'com.appyvet:materialrangebar:1.4.1'
 }
 ```
 


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.