### PR TITLE
Fix invalid nearestTickIndex issue

### DIFF
--- a/RangeBarSample/src/main/res/layout/activity_main.xml
+++ b/RangeBarSample/src/main/res/layout/activity_main.xml
@@ -25,6 +25,8 @@
         android:id="@+id/rangebar1"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginStart="40dp"
+        android:layout_marginEnd="40dp"
         app:mrb_pinMaxFont="10sp"
         app:mrb_rangeBarPaddingBottom="20dp"
         app:mrb_selectorBoundaryColor="@color/accent"

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.3'
         classpath "org.jfrog.buildinfo:build-info-extractor-gradle:3.1.1"
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Nov 29 17:50:20 CET 2017
+#Mon Jun 11 11:21:38 EDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/materialrangebar/src/main/java/com/appyvet/materialrangebar/Bar.java
+++ b/materialrangebar/src/main/java/com/appyvet/materialrangebar/Bar.java
@@ -1,14 +1,14 @@
 /*
- * Copyright 2013, Edmodo, Inc. 
+ * Copyright 2013, Edmodo, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License.
  * You may obtain a copy of the License in the LICENSE file, or at:
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" 
- * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language 
- * governing permissions and limitations under the License. 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
  */
 
 package com.appyvet.materialrangebar;
@@ -48,15 +48,15 @@ public class Bar {
     /**
      * Bar constructor
      *
-     * @param ctx          the context
-     * @param x            the start x co-ordinate
-     * @param y            the y co-ordinate
-     * @param length       the length of the bar in px
-     * @param tickCount    the number of ticks on the bar
+     * @param ctx        the context
+     * @param x          the start x co-ordinate
+     * @param y          the y co-ordinate
+     * @param length     the length of the bar in px
+     * @param tickCount  the number of ticks on the bar
      * @param tickHeight the height of each tick
-     * @param tickColor    the color of each tick
-     * @param barWeight    the weight of the bar
-     * @param barColor     the color of the bar
+     * @param tickColor  the color of each tick
+     * @param barWeight  the weight of the bar
+     * @param barColor   the color of the bar
      */
     public Bar(Context ctx,
                float x,
@@ -81,7 +81,7 @@ public class Bar {
         mBarPaint.setColor(barColor);
         mBarPaint.setStrokeWidth(barWeight);
         mBarPaint.setAntiAlias(true);
-        if(isBarRounded){
+        if (isBarRounded) {
             mBarPaint.setStrokeCap(Paint.Cap.ROUND);
         }
         mTickPaint = new Paint();
@@ -142,7 +142,14 @@ public class Bar {
      */
     public int getNearestTickIndex(PinView thumb) {
 
-        return (int) ((thumb.getX() - mLeftX + mTickDistance / 2f) / mTickDistance);
+        int tickIndex = (int) ((thumb.getX() - mLeftX + mTickDistance / 2f) / mTickDistance);
+
+        if (tickIndex > mNumSegments) {
+            tickIndex = mNumSegments;
+        } else if (tickIndex < 0) {
+            tickIndex = 0;
+        }
+        return tickIndex;
     }
 
 

--- a/materialrangebar/src/main/java/com/appyvet/materialrangebar/Bar.java
+++ b/materialrangebar/src/main/java/com/appyvet/materialrangebar/Bar.java
@@ -57,6 +57,7 @@ public class Bar {
      * @param tickColor  the color of each tick
      * @param barWeight  the weight of the bar
      * @param barColor   the color of the bar
+     * @param isBarRounded if the bar has rounded edges or not
      */
     public Bar(Context ctx,
                float x,


### PR DESCRIPTION
Fixes an issue where you were able to drag a thumb outside of the valid range. Typically reproduced by tapping on the **bar** and dragging past the end (or beginning) of the RangeBar. Added margin to start/end of sample (easier to reproduce the issue this way)