### PR TITLE
Add touch started and touch ended callbacks to listener

### DIFF
--- a/RangeBarSample/src/main/java/com/appyvet/rangebarsample/MainActivity.java
+++ b/RangeBarSample/src/main/java/com/appyvet/rangebarsample/MainActivity.java
@@ -121,6 +121,15 @@ public class MainActivity extends Activity implements
                 rightIndexValue.setText("" + rightPinIndex);
             }
 
+            @Override
+            public void onTouchEnded(RangeBar rangeBar) {
+                Log.d("RangeBar", "Touch ended");
+            }
+
+            @Override
+            public void onTouchStarted(RangeBar rangeBar) {
+                Log.d("RangeBar", "Touch started");
+            }
         });
 
         // Sets the indices themselves upon input from the user

--- a/materialrangebar/src/main/java/com/appyvet/materialrangebar/RangeBar.java
+++ b/materialrangebar/src/main/java/com/appyvet/materialrangebar/RangeBar.java
@@ -1037,6 +1037,9 @@ public class RangeBar extends View {
                         getPinValue(mLeftIndex), getPinValue(mRightIndex));
             }
         }
+
+        if (mListener != null)
+            mListener.onTouchEnded(this);
         invalidate();
         requestLayout();
     }

--- a/materialrangebar/src/main/java/com/appyvet/materialrangebar/RangeBar.java
+++ b/materialrangebar/src/main/java/com/appyvet/materialrangebar/RangeBar.java
@@ -1483,6 +1483,9 @@ public class RangeBar extends View {
                 pressPin(mRightThumb);
             }
         }
+
+        if (mListener != null)
+            mListener.onTouchStarted(this);
     }
 
     /**
@@ -1530,6 +1533,8 @@ public class RangeBar extends View {
                 }
             }
         }
+        if (mListener != null)
+            mListener.onTouchEnded(this);
     }
 
     /**
@@ -1699,6 +1704,10 @@ public class RangeBar extends View {
 
         void onRangeChangeListener(RangeBar rangeBar, int leftPinIndex,
                                    int rightPinIndex, String leftPinValue, String rightPinValue);
+
+        void onTouchStarted(RangeBar rangeBar);
+
+        void onTouchEnded(RangeBar rangeBar);
     }
 
     public interface PinTextFormatter {


### PR DESCRIPTION
There are use cases in which listener should not be called as the pin moves (let's assume a user has a heavy call on position changed). In this case, two new callbacks are convenient (onTouchStarted and onTouchEnded): when the pin moves, user can store its new value, and when touch ended, a heavy call can be executed with these positions