### PR TITLE
Add minimum range functionality

### DIFF
--- a/materialrangebar/src/main/java/com/appyvet/materialrangebar/Bar.java
+++ b/materialrangebar/src/main/java/com/appyvet/materialrangebar/Bar.java
@@ -331,6 +331,10 @@ public class Bar {
         return tickIndex;
     }
 
+    public float getTickX(int tickIndex) {
+        return mLeftX + (mRightX - mLeftX) / mNumSegments * tickIndex;
+    }
+
 
     /**
      * Set the number of ticks that will appear in the RangeBar.

--- a/materialrangebar/src/main/java/com/appyvet/materialrangebar/RangeBar.java
+++ b/materialrangebar/src/main/java/com/appyvet/materialrangebar/RangeBar.java
@@ -70,7 +70,7 @@ public class RangeBar extends View {
 
     private static final float DEFAULT_TICK_INTERVAL = 1;
 
-    private static final float DEFAULT_MIN_DISTANCE = 0;
+    private static final float DEFAULT_MIN_DISTANCE = -1;
 
     private static final float DEFAULT_TICK_HEIGHT_DP = 1;
 

--- a/materialrangebar/src/main/java/com/appyvet/materialrangebar/RangeBar.java
+++ b/materialrangebar/src/main/java/com/appyvet/materialrangebar/RangeBar.java
@@ -124,6 +124,8 @@ public class RangeBar extends View {
 
     private int mMinIndexDistance = 0;
 
+    float mDesiredMinDistance = -1f;
+
     private float mBarWeight = DEFAULT_BAR_WEIGHT_DP;
 
     private boolean mIsBarRounded = false;
@@ -1362,7 +1364,7 @@ public class RangeBar extends View {
                 mTickInterval = tickInterval;
                 mLeftIndex = 0;
                 mRightIndex = mTickCount - 1;
-                setMinimumThumbDistance(minDistance);
+                mDesiredMinDistance = minDistance;
 
                 if (mListener != null) {
                     mListener.onRangeChangeListener(this, mLeftIndex, mRightIndex,
@@ -1918,6 +1920,11 @@ public class RangeBar extends View {
      * Updates the thumbs' bounds based on the minimum distance, to their right and their left respectively.
      * */
     private void updateThumbBounds() {
+        mMinIndexDistance = (int) Math.ceil(mDesiredMinDistance / mTickInterval);
+        if (mMinIndexDistance > mTickCount - 1) {
+            Log.e(TAG, "Desired thumb distance greater than total range.");
+            mMinIndexDistance = mTickCount - 1;
+        }
         int maxIndexLeft = mRightIndex - mMinIndexDistance;
         int minIndexRight = mLeftIndex + mMinIndexDistance;
         mLeftBoundX = mBar.getTickX(Math.max(0, maxIndexLeft));
@@ -1947,11 +1954,7 @@ public class RangeBar extends View {
      * @param distance The desired minimum distance
      * */
     public void setMinimumThumbDistance(float distance) {
-        mMinIndexDistance = (int) Math.ceil(distance / mTickInterval);
-        if (mMinIndexDistance > mTickCount - 1) {
-            Log.e(TAG, "Thumb distance greater than total range.");
-            mMinIndexDistance = mTickCount - 1;
-        }
+        mDesiredMinDistance = distance;
     }
 
     // Inner Classes ///////////////////////////////////////////////////////////

--- a/materialrangebar/src/main/java/com/appyvet/materialrangebar/RangeBar.java
+++ b/materialrangebar/src/main/java/com/appyvet/materialrangebar/RangeBar.java
@@ -1359,7 +1359,7 @@ public class RangeBar extends View {
                 mTickInterval = tickInterval;
                 mLeftIndex = 0;
                 mRightIndex = mTickCount - 1;
-                setMinimumDistance(minDistance);
+                setMinimumThumbDistance(minDistance);
 
                 if (mListener != null) {
                     mListener.onRangeChangeListener(this, mLeftIndex, mRightIndex,
@@ -1926,7 +1926,12 @@ public class RangeBar extends View {
         return false;
     }
 
-    public void setMinimumDistance(float distance) {
+    /**
+     * Sets the minimum desired distance between thumb values.
+     *
+     * @param distance The desired minimum distance
+     * */
+    public void setMinimumThumbDistance(float distance) {
         mMinIndexDistance = (int) Math.ceil(distance / mTickInterval);
     }
 

--- a/materialrangebar/src/main/java/com/appyvet/materialrangebar/RangeBar.java
+++ b/materialrangebar/src/main/java/com/appyvet/materialrangebar/RangeBar.java
@@ -70,6 +70,8 @@ public class RangeBar extends View {
 
     private static final float DEFAULT_TICK_INTERVAL = 1;
 
+    private static final float DEFAULT_MIN_DISTANCE = 0;
+
     private static final float DEFAULT_TICK_HEIGHT_DP = 1;
 
     private static final float DEFAULT_PIN_PADDING_DP = 16;
@@ -119,6 +121,8 @@ public class RangeBar extends View {
     private float mTickEnd = DEFAULT_TICK_END;
 
     private float mTickInterval = DEFAULT_TICK_INTERVAL;
+
+    private int mMinIndexDistance = 0;
 
     private float mBarWeight = DEFAULT_BAR_WEIGHT_DP;
 
@@ -259,6 +263,8 @@ public class RangeBar extends View {
             }
         }
     };
+    private float mLeftBoundX;
+    private float mRightBoundX;
 
     // Constructors ////////////////////////////////////////////////////////////
 
@@ -319,6 +325,7 @@ public class RangeBar extends View {
         bundle.putBoolean("ARE_PINS_TEMPORARY", mArePinsTemporary);
         bundle.putInt("LEFT_INDEX", mLeftIndex);
         bundle.putInt("RIGHT_INDEX", mRightIndex);
+        bundle.putInt("MIN_INDEX_DISTANCE", mMinIndexDistance);
 
         bundle.putBoolean("FIRST_SET_TICK_COUNT", mFirstSetTickCount);
 
@@ -370,6 +377,7 @@ public class RangeBar extends View {
             mLeftIndex = bundle.getInt("LEFT_INDEX");
             mRightIndex = bundle.getInt("RIGHT_INDEX");
             mFirstSetTickCount = bundle.getBoolean("FIRST_SET_TICK_COUNT");
+            mMinIndexDistance = bundle.getInt("MIN_INDEX_DISTANCE");
 
             mMinPinFont = bundle.getFloat("MIN_PIN_FONT");
             mMaxPinFont = bundle.getFloat("MAX_PIN_FONT");
@@ -1338,6 +1346,8 @@ public class RangeBar extends View {
                     .getFloat(R.styleable.RangeBar_mrb_tickEnd, DEFAULT_TICK_END);
             final float tickInterval = ta
                     .getFloat(R.styleable.RangeBar_mrb_tickInterval, DEFAULT_TICK_INTERVAL);
+            final float minDistance = ta
+                    .getFloat(R.styleable.RangeBar_mrb_minSliderDistance, DEFAULT_MIN_DISTANCE);
             int tickCount = (int) ((tickEnd - tickStart) / tickInterval) + 1;
             if (isValidTickCount(tickCount)) {
 
@@ -1349,6 +1359,7 @@ public class RangeBar extends View {
                 mTickInterval = tickInterval;
                 mLeftIndex = 0;
                 mRightIndex = mTickCount - 1;
+                setMinimumDistance(minDistance);
 
                 if (mListener != null) {
                     mListener.onRangeChangeListener(this, mLeftIndex, mRightIndex,
@@ -1657,8 +1668,8 @@ public class RangeBar extends View {
     }
 
     /**
-     * Handles a {@link android.view.MotionEvent#ACTION_UP} or
-     * {@link android.view.MotionEvent#ACTION_CANCEL} event.
+     * Handles a {@link MotionEvent#ACTION_UP} or
+     * {@link MotionEvent#ACTION_CANCEL} event.
      *
      * @param x the x-coordinate of the up action
      * @param y the y-coordinate of the up action
@@ -1708,11 +1719,21 @@ public class RangeBar extends View {
     }
 
     /**
-     * Handles a {@link android.view.MotionEvent#ACTION_MOVE} event.
+     * Handles a {@link MotionEvent#ACTION_MOVE} event.
      *
      * @param x the x-coordinate of the move event
      */
     private void onActionMove(float x) {
+        int maxIndexLeft = mRightIndex - mMinIndexDistance;
+        int minIndexRight = mLeftIndex + mMinIndexDistance;
+        mLeftBoundX = mBar.getTickX(Math.max(0, maxIndexLeft));
+        mRightBoundX = mBar.getTickX(Math.min(getTickCount() - 1, minIndexRight));
+
+        if (mRightThumb.isPressed() && x < mRightBoundX) {
+            x = mRightBoundX;
+        } else if (mLeftThumb.isPressed() && x > mLeftBoundX) {
+            x = mLeftBoundX;
+        }
 
         // Move the pressed thumb to the new x-position.
         if (mIsRangeBar && mLeftThumb.isPressed()) {
@@ -1742,10 +1763,10 @@ public class RangeBar extends View {
             newRightIndex = getTickCount() - 1;
             movePin(mRightThumb, mBar.getRightX());
         }
+
         /// end added code
         // If either of the indices have changed, update and call the listener.
         if (newLeftIndex != mLeftIndex || newRightIndex != mRightIndex) {
-
             mLeftIndex = newLeftIndex;
             mRightIndex = newRightIndex;
             if (mIsRangeBar) {
@@ -1903,6 +1924,10 @@ public class RangeBar extends View {
             p = p.getParent();
         }
         return false;
+    }
+
+    public void setMinimumDistance(float distance) {
+        mMinIndexDistance = (int) Math.ceil(distance / mTickInterval);
     }
 
     // Inner Classes ///////////////////////////////////////////////////////////

--- a/materialrangebar/src/main/res/values/attrs.xml
+++ b/materialrangebar/src/main/res/values/attrs.xml
@@ -4,6 +4,7 @@
         <attr name="mrb_tickStart" format="float" />
         <attr name="mrb_tickEnd" format="float" />
         <attr name="mrb_tickInterval" format="float" />
+        <attr name="mrb_minSliderDistance" format="float"/>
         <attr name="mrb_tickHeight" format="dimension" />
         <attr name="mrb_tickDefaultColor" format="color" />
         <attr name="mrb_tickColors" format="reference" />


### PR DESCRIPTION
Adds support to keep both thumbs at a specified minimum distance to each other.
A minimum distance of 0 disables crossing thumbs.

Setting a minimum distance is optional: the default value of -1 provides the same behavior as the current version.