### PR TITLE
Select the nearest thumb when thumbs overlap

### DIFF
--- a/materialrangebar/src/main/java/com/appyvet/materialrangebar/RangeBar.java
+++ b/materialrangebar/src/main/java/com/appyvet/materialrangebar/RangeBar.java
@@ -1666,7 +1666,14 @@ public class RangeBar extends View {
      */
     private void onActionDown(float x, float y) {
         if (mIsRangeBar) {
-            if (!mRightThumb.isPressed() && mLeftThumb.isInTargetZone(x, y)) {
+            // If both target zones overlap, determine the nearest one.
+            if (mLeftThumb.isInTargetZone(x, y) && mRightThumb.isInTargetZone(x, y)) {
+                if (getLeftThumbXDistance(x) < getRightThumbXDistance(x) && !mRightThumb.isPressed()) {
+                    pressPin(mLeftThumb);
+                } else if (!mLeftThumb.isPressed()) {
+                    pressPin(mRightThumb);
+                }
+            } else if (!mRightThumb.isPressed() && mLeftThumb.isInTargetZone(x, y)) {
 
                 pressPin(mLeftThumb);
 


### PR DESCRIPTION
**Issue**
In a RangeBar, when thumb target zones overlap, there's always the left thumb selected. This results in an unpleasant user experience.

![NearbyThumbsIssueDemonstration](https://user-images.githubusercontent.com/38349989/84397990-a6b34c80-abff-11ea-8cc4-69e3e0093fec.gif)

**Solution**
Simple: when a touch-down event has an x offset included in both target zones, check which thumb is nearer to the touch's x.

![NearbyThumbsSolutionDemonstration](https://user-images.githubusercontent.com/38349989/84398005-aa46d380-abff-11ea-971a-0422e3aedb27.gif)

