### PR TITLE
Fix minimum distance changing unintentionally when tick interval updated to != 1 (#189)

### DIFF
--- a/materialrangebar/src/main/java/com/appyvet/materialrangebar/RangeBar.java
+++ b/materialrangebar/src/main/java/com/appyvet/materialrangebar/RangeBar.java
@@ -1933,7 +1933,7 @@ public class RangeBar extends View {
      * Updates the Thumbs bounds based on the minimum distance, to their right and their left respectively.
      */
     private void updateThumbBounds() {
-        mMinIndexDistance = (int) Math.ceil(mDesiredMinDistance / mTickInterval);
+        mMinIndexDistance = mDesiredMinDistance < 0 ? -1 : (int) Math.ceil(mDesiredMinDistance / mTickInterval);
         if (mMinIndexDistance > mTickCount - 1) {
             Log.e(TAG, "Desired thumb distance greater than total range.");
             mMinIndexDistance = mTickCount - 1;


### PR DESCRIPTION
Fixes issue #189 

**Issue**
When tick interval is not 1, thumbs cannot move across each other anymore.

**Solution**
Fix is simple: do not update the distance when desired distance is -1...